### PR TITLE
docs: add mdBook manual and slim README

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,77 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install mdBook
+        run: cargo install mdbook --version 0.5.3 --locked
+
+      - name: Build mdBook
+        run: mdbook build docs
+
+      - name: Configure GitHub Pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs/book
+
+  deploy:
+    name: Deploy docs
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ dist/
 # Test coverage
 coverage/
 
+# mdBook output
+docs/book/
+
 # Logs
 npm-debug.log*
 yarn-debug.log*

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,5 +8,6 @@ yarn.lock
 # build/artifacts
 dist/
 coverage/
+docs/book/
 node_modules/
 __tests__/

--- a/README.md
+++ b/README.md
@@ -1,596 +1,160 @@
 # Supabase Error Translator JS
 
-A comprehensive Supabase error code translator supporting 10 languages with ISO language codes
+A small TypeScript package that translates Supabase error codes into user-facing messages
+across 10 languages.
 
-> **DISCLAIMER:** This is a private project and is NOT officially associated with, endorsed by, or affiliated with Supabase in any way. This project is maintained independently.
+> **Disclaimer:** This project is maintained independently. It is not officially
+> associated with, endorsed by, or affiliated with Supabase.
 
-[![CI](https://github.com/srothgan/supabase-error-translator-js/actions/workflows/ci.yaml/badge.svg)](https://github.com/srothgan/supabase-error-translator-js/actions/workflows/ci.yaml)
-[![CodeQL](https://github.com/srothgan/supabase-error-translator-js/actions/workflows/codeql.yml/badge.svg)](https://github.com/srothgan/supabase-error-translator-js/actions/workflows/codeql.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![npm version](https://img.shields.io/npm/v/supabase-error-translator-js)](https://www.npmjs.com/package/supabase-error-translator-js)
 [![npm downloads](https://img.shields.io/npm/dm/supabase-error-translator-js.svg)](https://www.npmjs.com/package/supabase-error-translator-js)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://srothgan.github.io/supabase-error-translator-js/)
+[![CI](https://github.com/srothgan/supabase-error-translator-js/actions/workflows/ci.yaml/badge.svg)](https://github.com/srothgan/supabase-error-translator-js/actions/workflows/ci.yaml)
+[![CodeQL](https://github.com/srothgan/supabase-error-translator-js/actions/workflows/codeql.yml/badge.svg)](https://github.com/srothgan/supabase-error-translator-js/actions/workflows/codeql.yml)
 
-## Table of Contents
+## About
 
-- [Overview](#overview)
-- [Installation](#installation)
-- [Usage](#usage)
-  - [Basic Usage](#basic-usage)
-  - [Auto-Detect Browser Language](#auto-detect-browser-language)
-  - [Get Current Language and Supported Languages](#get-current-language-and-supported-languages)
-  - [Override Language for Specific Translations](#override-language-for-specific-translations)
-- [Error Handling and Fallbacks](#error-handling-and-fallbacks)
-- [API Reference](#api-reference)
-- [Examples](#examples)
-  - [Auth Error](#auth-error)
-  - [Database Error](#database-error)
-  - [Storage Error](#storage-error)
-  - [Realtime Error](#realtime-error)
+`supabase-error-translator-js` maps Supabase Auth, Storage, Realtime, and database error
+codes to localized text. It does not call Supabase and has no runtime dependency on
+`@supabase/supabase-js`.
 
-- [Supported Error Codes](#supported-error-codes)
-- [Roadmap](#roadmap)
-- [Changelog](#changelog)
-- [Contributing](#contributing)
-- [License](#license)
-
-## Overview
-
-This library provides translations for Supabase error codes and messages in multiple languages. It's designed to help developers create a better user experience by displaying localized error messages to users based on their preferred language.
-
-## Supported Languages
+Supported languages:
 
 | Language   | Code | Native Name |
 | ---------- | ---- | ----------- |
 | English    | `en` | English     |
 | Arabic     | `ar` | العربية     |
 | German     | `de` | Deutsch     |
-| Spanish    | `es` | Español     |
-| French     | `fr` | Français    |
-| Japanese   | `ja` | 日本語      |
-| Korean     | `ko` | 한국어      |
+| Spanish    | `es` | Espanol     |
+| French     | `fr` | Francais    |
+| Japanese   | `ja` | Japanese    |
+| Korean     | `ko` | Korean      |
 | Polish     | `pl` | Polski      |
-| Portuguese | `pt` | Português   |
-| Chinese    | `zh` | 中文        |
+| Portuguese | `pt` | Portugues   |
+| Chinese    | `zh` | Chinese     |
 
-## Installation
+Supported service keys:
 
-```bash
-npm install supabase-error-translator-js
+```text
+auth, storage, realtime, database, functions
 ```
 
-or
-
-```bash
-yarn add supabase-error-translator-js
-```
-
-## Usage
-
-### Basic Usage
-
-```typescript
-import { translateErrorCode, setLanguage } from 'supabase-error-translator-js';
-
-// Set the language (defaults to English if not set)
-setLanguage('es'); // Set to Spanish
-
-// Translate an error code
-const message = translateErrorCode('email_not_confirmed', 'auth');
-console.log(message); // Outputs the Spanish translation for this error code
-```
-
-### Auto-Detect Browser Language
-
-```typescript
-import { setLanguage, translateErrorCode } from 'supabase-error-translator-js';
-
-// Automatically detect and use the browser's language
-setLanguage('auto');
-
-// Translate an error code using the detected language
-const message = translateErrorCode('invalid_credentials', 'auth');
-console.log(message);
-```
-
-### Get Current Language and Supported Languages
-
-```typescript
-import { getCurrentLanguage, getSupportedLanguages } from 'supabase-error-translator-js';
-
-// Get the currently active language
-const currentLang = getCurrentLanguage();
-console.log(currentLang); // e.g., 'en', 'de', etc.
-
-// Get all supported languages
-const supportedLangs = getSupportedLanguages();
-console.log(supportedLangs); // ['en', 'ar', 'de', 'es', 'fr', 'ja', 'ko', 'pl', 'pt', 'zh']
-```
-
-### Override Language for Specific Translations
-
-```typescript
-import { translateErrorCode } from 'supabase-error-translator-js';
-
-// Translate using a specific language (without changing the default)
-const message = translateErrorCode('phone_exists', 'auth', 'fr');
-console.log(message); // French translation
-```
-
-## Error Handling and Fallbacks
-
-We normalize any empty or whitespace-only code to the special key `unknown_error` before doing any locale lookups. From there, we follow a four-step, industry-standard fallback chain:
-
-1. **Service-specific locale lookup**: First try `translations[target].services[service][key]` - looking for the error code in the specified service in the user's language.
-
-2. **Service-specific English lookup**: If not found in the target language, try `translations.en.services[service][key]` - looking for the error code in the specified service in English.
-
-3. **Generic locale fallback**: If the service-specific code isn't found, try `translations[target].unknown_error` - the generic unknown error message in the user's language.
-
-4. **Generic English fallback**: Finally, return `translations.en.unknown_error` - the generic unknown error message in English.
-
-This enhanced fallback chain ensures that:
-
-- Service-specific error codes are properly translated
-- Blank or unrecognized codes first yield a localized "unknown error" message before falling back to English
-- The system is resilient to missing translations in any language or service
-- Special handling for direct "unknown_error" requests bypasses service-specific lookups for efficiency
-
-The `service` parameter allows the system to correctly handle cases where the same error code exists in multiple Supabase services with different meanings and contexts.
-
-## API Reference
-
-### `setLanguage(lang: SupportedLanguage | "auto"): void`
-
-Sets the current language for translations. If "auto" is passed, it will attempt to detect the browser's language.
-
-- **Parameters:**
-  - `lang`: A supported ISO language code ('en', 'ar', 'de', 'es', 'fr', 'ja', 'ko', 'pl', 'pt', 'zh') or "auto"
-- **Behavior:**
-  - If an unsupported language is provided, falls back to English ('en')
-
-### `translateErrorCode(code?: string, service: ErrorService, lang?: SupportedLanguage | "auto"): string`
-
-Translates a Supabase error code into localized text, normalizing blank or missing codes to unknown_error.
-
-- **Parameters:**
-  - `code?`: The Supabase error code to translate. If undefined or empty, treated as "unknown_error".
-  - `service`: The Supabase service that generated the error:
-    - 'auth' - Authentication and user management errors
-    - 'storage' - File storage errors
-    - 'realtime' - Realtime subscription errors
-    - 'database' - Database query errors
-    - 'functions' - Edge Functions errors
-  - `lang?`: (Optional)
-    - Omitted → use currentLanguage
-    - "auto" → detect via detectBrowserLanguage(), fallback to 'en' if unsupported
-    - Any other value → if unsupported, fallback to 'en'
-
-- **Returns:**
-  - The translated message, using this lookup chain:
-    1. translations[target].services[service][key]
-    2. translations.en.services[service][key]
-    3. translations[target].unknown_error
-    4. translations.en.unknown_error
-
-### `getCurrentLanguage(): SupportedLanguage`
-
-Returns the currently active language.
-
-- **Returns:**
-  - The current language code as a string
-
-### `getSupportedLanguages(): SupportedLanguage[]`
-
-Returns an array of all supported language codes.
-
-- **Returns:**
-  - Array of supported language codes
-
-## Examples
-
-### Auth Error
-
-```jsx
-import React, { useState, useEffect } from 'react';
-import { setLanguage, translateErrorCode } from 'supabase-error-translator-js';
-import { supabase } from './supabaseClient';
-import { useRouter } from 'next/navigation';
-
-function SignupForm() {
-  const router = useRouter();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState(null);
-  const [isLoading, setIsLoading] = useState(false);
-
-  useEffect(() => {
-    // Set language
-    setLanguage('de');
-  }, []);
-
-  const handleSignup = async (e) => {
-    e.preventDefault();
-    setError(null);
-    setIsLoading(true);
-
-    try {
-      const { error } = await supabase.auth.signUp({
-        email,
-        password,
-      });
-
-      if (error) {
-        // Translate the error code from Supabase
-        const translatedError = translateErrorCode(error.code, 'auth');
-        setError(translatedError);
-      } else {
-        // Navigate to login page in Next.js 15
-        router.push('/login');
-        // Clear form
-        setEmail('');
-        setPassword('');
-      }
-    } catch (err) {
-      setError(translateErrorCode('unknown_error', 'auth'));
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  return (
-    <form onSubmit={handleSignup}>
-      {error && <div className="error">{error}</div>}
-
-      <input
-        type="email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder="Email"
-        required
-        disabled={isLoading}
-      />
-      <input
-        type="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        placeholder="Passwort"
-        required
-        disabled={isLoading}
-      />
-      {/* Keep UI text in native language */}
-      <button type="submit" disabled={isLoading}>
-        {isLoading ? 'Wird angemeldet...' : 'Anmelden'}
-      </button>
-    </form>
-  );
-}
-```
-
-### Database Error
-
-```jsx
-import React, { useState, useEffect } from 'react';
-import { setLanguage, translateErrorCode } from 'supabase-error-translator-js';
-import { supabase } from './supabaseClient';
-
-function ProductForm() {
-  const [name, setName] = useState('');
-  const [price, setPrice] = useState('');
-  const [description, setDescription] = useState('');
-  const [error, setError] = useState(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [successMessage, setSuccessMessage] = useState('');
-
-  useEffect(() => {
-    // Set language to German
-    setLanguage('de');
-  }, []);
-
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    setError(null);
-    setSuccessMessage('');
-    setIsSubmitting(true);
-
-    // Basic validation
-    if (!name || !price) {
-      setError('Bitte fülle alle Pflichtfelder aus.');
-      setIsSubmitting(false);
-      return;
-    }
-
-    try {
-      // Attempt to insert a new product into the database
-      const { data, error: dbError } = await supabase
-        .from('products')
-        .insert([
-          {
-            name,
-            price: parseFloat(price),
-            description,
-            created_at: new Date(),
-          },
-        ])
-        .select();
-
-      if (dbError) {
-        // Simply translate the database error code
-        const translatedError = translateErrorCode(dbError.code, 'database');
-        setError(translatedError);
-      } else {
-        // Clear the form and show success message
-        setName('');
-        setPrice('');
-        setDescription('');
-        setSuccessMessage('Produkt erfolgreich gespeichert!');
-      }
-    } catch (err) {
-      // Handle unexpected errors
-      setError(translateErrorCode('unknown_error', 'database'));
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <div className="product-form">
-      <h2>Neues Produkt hinzufügen</h2>
-
-      {error && <div className="error-message">{error}</div>}
-      {successMessage && <div className="success-message">{successMessage}</div>}
-
-      <form onSubmit={handleSubmit}>
-        <div className="form-group">
-          <label htmlFor="name">Produktname*</label>
-          <input
-            id="name"
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            disabled={isSubmitting}
-            required
-          />
-        </div>
-
-        <div className="form-group">
-          <label htmlFor="price">Preis (€)*</label>
-          <input
-            id="price"
-            type="number"
-            step="0.01"
-            min="0"
-            value={price}
-            onChange={(e) => setPrice(e.target.value)}
-            disabled={isSubmitting}
-            required
-          />
-        </div>
-
-        <div className="form-group">
-          <label htmlFor="description">Beschreibung</label>
-          <textarea
-            id="description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            disabled={isSubmitting}
-            rows={4}
-          />
-        </div>
-
-        <button type="submit" disabled={isSubmitting}>
-          {isSubmitting ? 'Wird gespeichert...' : 'Produkt speichern'}
-        </button>
-      </form>
-    </div>
-  );
-}
-
-export default ProductForm;
-```
-
-### Storage Error
-
-```jsx
-import React, { useState, useEffect } from 'react';
-import { setLanguage, translateErrorCode } from 'supabase-error-translator-js';
-import { supabase } from './supabaseClient';
-
-function FileUploader() {
-  const [file, setFile] = useState(null);
-  const [error, setError] = useState(null);
-  const [isUploading, setIsUploading] = useState(false);
-
-  useEffect(() => {
-    // Set language
-    setLanguage('es');
-  }, []);
-
-  const handleFileChange = (event) => {
-    setFile(event.target.files);
-    setError(null); // Clear previous errors
-  };
-
-  const handleUpload = async () => {
-    if (!file) {
-      setError('Por favor, selecciona un archivo para subir.'); // Example of a non-Supabase error
-      return;
-    }
-
-    setIsUploading(true);
-    setError(null);
-
-    try {
-      const { data, error: uploadError } = await supabase.storage
-        .from('your-bucket-name') // Replace with your bucket name
-        .upload(`public/${file.name}`, file);
-
-      if (uploadError) {
-        // translate error code if existing
-        const translatedError = translateErrorCode(uploadError.code, 'storage');
-        setError(translatedError);
-      } else {
-        console.log('File uploaded successfully:', data);
-        // Handle success (e.g., show a success message or clear the form)
-        setFile(null);
-      }
-    } catch (err) {
-      // Assuming a general error during the async operation should use unknown_error
-      setError(translateErrorCode('unknown_error', 'storage'));
-    } finally {
-      setIsUploading(false);
-    }
-  };
-
-  return (
-    <div>
-      {error && <div className="error">{error}</div>}
-      <input type="file" onChange={handleFileChange} disabled={isUploading} />
-      <button onClick={handleUpload} disabled={!file || isUploading}>
-        {isUploading ? 'Subiendo...' : 'Subir Archivo'}
-      </button>
-    </div>
-  );
-}
-```
-
-### Realtime Error
-
-```jsx
-import React, { useState, useEffect } from 'react';
-import { setLanguage, translateErrorCode } from 'supabase-error-translator-js';
-import { supabase } from './supabaseClient';
-
-function RealtimeListener() {
-  const [realtimeError, setRealtimeError] = useState(null);
-  const [messages, setMessages] = useState([]); // To show received messages
-
-  useEffect(() => {
-    // Set language
-    setLanguage('fr');
-
-    // Subscribe to a channel
-    const channel = supabase
-      .channel('my-realtime-channel') // Replace with your channel name
-      .on('broadcast', { event: 'my-event' }, (payload) => {
-        console.log('Realtime message received:', payload);
-        setMessages((prevMessages) => [...prevMessages, payload.payload]);
-      })
-      // Error handling for the channel
-      .subscribe((status, err) => {
-        if (status === 'CHANNEL_ERROR') {
-          console.error('Realtime Channel Error:', err);
-          if (err) {
-            // Check for error code
-            // Attempt to translate the Realtime error code
-            const translatedError = translateErrorCode(err.code, 'realtime');
-            setRealtimeError(translatedError);
-          } else {
-            // Fallback for unexpected Realtime error structures
-            setRealtimeError(translateErrorCode('unknown_error', 'realtime'));
-          }
-        } else if (status === 'TIMED_OUT') {
-          // Handle specific Realtime statuses if needed
-          setRealtimeError('Connexion Realtime expirée. Veuillez réessayer.');
-        }
-      });
-
-    // Clean up subscription on component unmount
-    return () => {
-      supabase.removeChannel(channel);
-    };
-  }, []); // Empty dependency array means this effect runs once on mount
-
-  return (
-    <div>
-      <h2>Messages Realtime</h2>
-      {realtimeError && <div className="error">{realtimeError}</div>}
-      <ul>
-        {messages.map((msg, index) => (
-          <li key={index}>{JSON.stringify(msg)}</li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-```
+`functions` is accepted by the API, but its translation maps are currently empty and will
+return the unknown-error fallback.
 
 ## Supported Error Codes
 
 The library supports numerous Supabase error codes, including but not limited to:
 
 - Auth
-  - Authentication errors (invalid credentials, email not confirmed, etc.)
-  - User management errors (user not found, already exists, etc.)
-  - Rate limiting errors (too many requests, over email send rate, etc.)
-  - MFA-related errors (challenge expired, verification failed, etc.)
-  - OAuth and SSO errors (provider disabled, bad callback, etc.)
+  - Authentication errors: invalid credentials, email not confirmed, and related sign-in
+    failures
+  - User management errors: user not found, already exists, and identity conflicts
+  - Rate limiting errors: too many requests, email send rate limits, and SMS send limits
+  - MFA-related errors: expired challenges, failed verification, and disabled factors
+  - OAuth and SSO errors: disabled providers, bad callbacks, and SAML/SSO configuration
+    issues
 - Realtime
-  - Configuration errors (disabled realtime, tenant not found, etc.)
-  - Connection errors (WebSocket connection issues, authorization failures)
-  - Rate limiting errors (channel limits, connection limits, join rate limits)
-  - Database errors (CDC stream issues, replication slot problems)
-  - System errors (node disconnection, migration failures, counter tracking errors)
+  - Configuration errors: disabled realtime, tenant not found, and table setup issues
+  - Connection errors: WebSocket connection and authorization failures
+  - Rate limiting errors: channel, connection, and join rate limits
+  - Database errors: CDC stream, replication slot, and subscription failures
+  - System errors: node disconnection, migration failures, and counter tracking errors
 - Storage
-  - Resource errors (bucket/file not found, already exists, etc.)
-  - Authorization errors (invalid tokens, access denied, etc.)
-  - Validation errors (invalid input parameters, formats, etc.)
-  - Service limitations (size restrictions, rate limits, etc.)
-  - Infrastructure errors (database issues, internal errors, etc.)
+  - Resource errors: bucket, file, upload, and key not found or already exists
+  - Authorization errors: invalid tokens, invalid signatures, and access denied
+  - Validation errors: invalid parameters, bucket names, keys, ranges, and MIME types
+  - Service limitations: size limits, credential limits, locks, and request slowdown
+  - Infrastructure errors: database timeouts, database errors, and internal errors
 - Database
-  - Connection errors (server disconnections, failed connections, etc.)
-  - Data type errors (type mismatches, invalid conversions, overflow errors)
-  - Constraint violations (unique, foreign key, not-null, check constraints)
-  - Access and authentication errors (permission denied, authentication failures)
-  - Resource limitations (memory constraints, connection limits, disk space)
-  - Query syntax issues (syntax errors, invalid object names, ambiguous references)
-  - Transaction errors (serialization failures, deadlocks, aborted transactions)
-  - PostgREST-specific errors (JWT validation, schema visibility, API request issues)
-  - Server-side errors (assertion failures, resource unavailability, timeouts)
+  - Connection errors: server disconnections, inactive connections, and failed connections
+  - Data type errors: type mismatches, invalid conversions, overflow, and invalid dates
+  - Constraint violations: unique, foreign key, not-null, and check constraints
+  - Access and authentication errors: permission denied and authentication failures
+  - Resource limitations: memory, disk, connection, and program limits
+  - Query syntax issues: syntax errors, invalid names, missing objects, and ambiguous
+    references
+  - Transaction errors: serialization failures, deadlocks, and aborted transactions
+  - PostgREST-specific errors: JWT validation, schema visibility, and API request issues
+  - Server-side errors: assertions, unavailable resources, cancellations, and timeouts
 
 Each error code is translated according to the specified language.
 
-## Roadmap
+## Install
 
-We're actively expanding support for additional Supabase error domains and languages. Current status:
+```bash
+npm install supabase-error-translator-js
+```
 
-**Error Domains:**
+```bash
+pnpm add supabase-error-translator-js
+```
 
-- **Storage**: ✅ Done
-- **Realtime**: ✅ Done
-- **Auth**: ✅ Done
-- **Database**: ✅ Done
-- **Functions**: 🔄 Coming soon
+```bash
+yarn add supabase-error-translator-js
+```
 
-**Language Support:**
+## Quick Start
 
-- **Core Languages**: ✅ 10 languages now supported
-- **Additional Languages**: 🔄 Open to community contributions for more languages
+```ts
+import { translateErrorCode } from 'supabase-error-translator-js';
+
+const message = translateErrorCode('invalid_credentials', 'auth', 'de');
+```
+
+Set a default language:
+
+```ts
+import { setLanguage, translateErrorCode } from 'supabase-error-translator-js';
+
+setLanguage('es');
+
+const message = translateErrorCode('email_not_confirmed', 'auth');
+```
+
+For request-scoped server code, prefer passing the language directly to
+`translateErrorCode()` instead of using the module-level default.
+
+## Documentation
+
+The manual covers installation, language handling, fallback behavior, API reference,
+examples, and migration guides:
+
+- [Installation](https://srothgan.github.io/supabase-error-translator-js/installation.html)
+- [Quick Start](https://srothgan.github.io/supabase-error-translator-js/quick-start.html)
+- [Language Handling](https://srothgan.github.io/supabase-error-translator-js/language-handling.html)
+- [Services and Fallbacks](https://srothgan.github.io/supabase-error-translator-js/services-and-fallbacks.html)
+- [API Reference](https://srothgan.github.io/supabase-error-translator-js/api-reference.html)
+- [Examples](https://srothgan.github.io/supabase-error-translator-js/examples.html)
+- [Migration Guide](https://srothgan.github.io/supabase-error-translator-js/migration.html)
+
+## API
+
+```ts
+import {
+  getCurrentLanguage,
+  getSupportedLanguages,
+  isSupportedLanguage,
+  isSupportedService,
+  setLanguage,
+  translateErrorCode,
+  SUPPORTED_LANGUAGES,
+  SUPPORTED_SERVICES,
+  type ErrorService,
+  type SupportedLanguage,
+} from 'supabase-error-translator-js';
+```
 
 ## Changelog
 
-**Latest Version: 3.0.1 - 30.08.2025**
-
-- Build cleanup: clean `dist` before build to remove stale translation bundles after ISO migration (removes old `cn`/`jp`/`kr` outputs)
-- No API changes
-
-**Version: 3.0.0 - 29.08.2025**
-
-- **🚨 BREAKING CHANGE: Migrated to proper ISO 639-1 language codes**
-  - `jp` → `ja` (Japanese)
-  - `kr` → `ko` (Korean)
-  - `cn` → `zh` (Chinese)
-- Fixed behavior: `translateErrorCode()` without `lang` parameter now correctly uses `currentLanguage` instead of browser detection
-- All existing translations maintained with new language codes
-- Improved compliance with international standards
-
-For detailed release notes and migration guides, see the [full CHANGELOG](CHANGELOG.md).
+See [CHANGELOG.md](CHANGELOG.md) for release notes and migration details.
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to this project.
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the development
+workflow.
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE) - see the LICENSE file for details.
+This project is licensed under the [MIT License](LICENSE).

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,17 @@
+[book]
+title = "Supabase Error Translator JS"
+authors = ["Simon Peter Rothgang"]
+description = "Usage and API documentation for supabase-error-translator-js."
+language = "en"
+src = "src"
+
+[build]
+build-dir = "book"
+create-missing = false
+
+[output.html]
+git-repository-url = "https://github.com/srothgan/supabase-error-translator-js"
+edit-url-template = "https://github.com/srothgan/supabase-error-translator-js/edit/main/docs/{path}"
+site-url = "/supabase-error-translator-js/"
+preferred-dark-theme = "ayu"
+no-section-label = true

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,12 @@
+# Summary
+
+- [About](about.md)
+- [Installation](installation.md)
+- [Quick Start](quick-start.md)
+- [Language Handling](language-handling.md)
+- [Services and Fallbacks](services-and-fallbacks.md)
+- [API Reference](api-reference.md)
+- [Examples](examples.md)
+- [Migration Guide](migration.md)
+- [Contributing](contributing.md)
+- [Changelog](changelog.md)

--- a/docs/src/about.md
+++ b/docs/src/about.md
@@ -1,0 +1,42 @@
+# About
+
+`supabase-error-translator-js` maps Supabase error codes to user-facing messages in
+multiple languages. It is useful when your app receives technical error codes from
+Supabase Auth, Storage, Realtime, or PostgREST and needs a localized message for the UI.
+
+The package does not call Supabase and does not depend on `@supabase/supabase-js`. It is a
+small translation registry plus a few helper functions.
+
+> This project is maintained independently. It is not officially associated with,
+> endorsed by, or affiliated with Supabase.
+
+## Supported Languages
+
+| Language   | Code |
+| ---------- | ---- |
+| English    | `en` |
+| Arabic     | `ar` |
+| German     | `de` |
+| Spanish    | `es` |
+| French     | `fr` |
+| Japanese   | `ja` |
+| Korean     | `ko` |
+| Polish     | `pl` |
+| Portuguese | `pt` |
+| Chinese    | `zh` |
+
+## Supported Services
+
+| Service     | Status                                                                                                       |
+| ----------- | ------------------------------------------------------------------------------------------------------------ |
+| `auth`      | Translated error codes are available.                                                                        |
+| `storage`   | Translated error codes are available.                                                                        |
+| `realtime`  | Translated error codes are available.                                                                        |
+| `database`  | PostgreSQL and PostgREST error codes are available.                                                          |
+| `functions` | The service is accepted by the API, but translations are currently empty. Unknown fallback text is returned. |
+
+## What The Package Returns
+
+The package returns strings, not rich error objects. It intentionally keeps the public API
+simple so callers can use the result in React, Next.js, Node.js, or any browser-bundled
+application.

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -1,0 +1,77 @@
+# API Reference
+
+## `setLanguage(lang)`
+
+```ts
+function setLanguage(lang: SupportedLanguage | 'auto'): void;
+```
+
+Sets the module-level default language.
+
+| Argument | Description                                                                           |
+| -------- | ------------------------------------------------------------------------------------- |
+| `lang`   | A supported language code or `auto`. Unsupported values fall back to `en` at runtime. |
+
+Use per-call language overrides instead of `setLanguage()` in request-scoped server code.
+
+## `translateErrorCode(code, service, lang?)`
+
+```ts
+function translateErrorCode(
+  code: string | undefined,
+  service: ErrorService,
+  lang?: SupportedLanguage | 'auto',
+): string;
+```
+
+Returns a translated string for a Supabase error code.
+
+| Argument  | Description                                                                                          |
+| --------- | ---------------------------------------------------------------------------------------------------- |
+| `code`    | The Supabase error code. Empty, whitespace-only, or undefined values are treated as `unknown_error`. |
+| `service` | One of `auth`, `storage`, `realtime`, `database`, or `functions`.                                    |
+| `lang`    | Optional per-call language override. `auto` uses browser detection.                                  |
+
+## `getCurrentLanguage()`
+
+```ts
+function getCurrentLanguage(): SupportedLanguage;
+```
+
+Returns the current module-level default language.
+
+## `getSupportedLanguages()`
+
+```ts
+function getSupportedLanguages(): SupportedLanguage[];
+```
+
+Returns a copy of the supported language-code list.
+
+## `isSupportedLanguage(lang)`
+
+```ts
+function isSupportedLanguage(lang: string): lang is SupportedLanguage;
+```
+
+Runtime guard for supported language codes.
+
+## `isSupportedService(service)`
+
+```ts
+function isSupportedService(service: string): service is ErrorService;
+```
+
+Runtime guard for supported service names.
+
+## Constants And Types
+
+```ts
+import {
+  SUPPORTED_LANGUAGES,
+  SUPPORTED_SERVICES,
+  type ErrorService,
+  type SupportedLanguage,
+  type TranslationStructure,
+} from 'supabase-error-translator-js';
+```

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,0 +1,23 @@
+# Changelog
+
+The canonical changelog lives in the repository root:
+
+[CHANGELOG.md](https://github.com/srothgan/supabase-error-translator-js/blob/main/CHANGELOG.md)
+
+## Recent Highlights
+
+### 3.0.1
+
+- Cleaned stale build output before compiling.
+- No API changes.
+
+### 3.0.0
+
+- Migrated Japanese, Korean, and Chinese language codes to ISO 639-1:
+  `ja`, `ko`, and `zh`.
+- Fixed default-language behavior for `translateErrorCode()`.
+
+### 2.0.0
+
+- Introduced service-specific translation maps.
+- Changed `translateErrorCode(code, lang?)` to `translateErrorCode(code, service, lang?)`.

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -1,0 +1,47 @@
+# Contributing
+
+See the repository
+[contribution guide](https://github.com/srothgan/supabase-error-translator-js/blob/main/CONTRIBUTING.md)
+for the full workflow.
+
+## Local Setup
+
+```bash
+pnpm install
+```
+
+## Checks
+
+```bash
+pnpm run lint
+pnpm run type-check
+pnpm test
+pnpm run build
+pnpm run prettier:check
+```
+
+## Translation Changes
+
+When adding or changing translations:
+
+1. Keep every language map structurally aligned with English.
+2. Add or update tests when the public behavior changes.
+3. Keep `unknown_error` defined for every language.
+4. Document new public behavior in this manual.
+
+The test suite checks that every supported language defines the same service keys as the
+English translation map.
+
+## Documentation
+
+Build the mdBook locally:
+
+```bash
+mdbook build docs
+```
+
+Serve it locally while editing:
+
+```bash
+mdbook serve docs
+```

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,0 +1,110 @@
+# Examples
+
+## Supabase Auth
+
+```tsx
+import { useState, type FormEvent } from 'react';
+import { translateErrorCode, type SupportedLanguage } from 'supabase-error-translator-js';
+import { supabase } from './supabaseClient';
+
+type Props = {
+  language: SupportedLanguage;
+};
+
+export function SignInForm({ language }: Props) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function signIn(event: FormEvent) {
+    event.preventDefault();
+    setErrorMessage(null);
+
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+
+    if (error) {
+      setErrorMessage(translateErrorCode(error.code, 'auth', language));
+    }
+  }
+
+  return (
+    <form onSubmit={signIn}>
+      {errorMessage && <p role="alert">{errorMessage}</p>}
+      <input value={email} onChange={(event) => setEmail(event.target.value)} />
+      <input
+        type="password"
+        value={password}
+        onChange={(event) => setPassword(event.target.value)}
+      />
+      <button type="submit">Sign in</button>
+    </form>
+  );
+}
+```
+
+## Database And PostgREST
+
+Database errors often expose SQLSTATE codes such as `23505` or PostgREST codes such as
+`PGRST204`.
+
+```ts
+import { translateErrorCode } from 'supabase-error-translator-js';
+import { supabase } from './supabaseClient';
+
+const { error } = await supabase.from('profiles').insert({
+  username: 'existing-user',
+});
+
+if (error) {
+  const message = translateErrorCode(error.code, 'database', 'en');
+  console.log(message);
+}
+```
+
+## Storage
+
+```ts
+import { translateErrorCode } from 'supabase-error-translator-js';
+import { supabase } from './supabaseClient';
+
+async function uploadAvatar(file: File) {
+  const { error } = await supabase.storage.from('avatars').upload('public/avatar.png', file);
+
+  if (error) {
+    const message = translateErrorCode(error.code, 'storage', 'es');
+    console.log(message);
+  }
+}
+```
+
+## Realtime
+
+Realtime status callbacks do not always include a structured error. Use
+`unknown_error` when no code is present.
+
+```ts
+import { translateErrorCode } from 'supabase-error-translator-js';
+import { supabase } from './supabaseClient';
+
+const channel = supabase.channel('room').subscribe((status, error) => {
+  if (status === 'CHANNEL_ERROR') {
+    const message = translateErrorCode(error?.code, 'realtime', 'fr');
+    console.log(message);
+  }
+});
+```
+
+## Runtime Guards
+
+```ts
+import {
+  isSupportedLanguage,
+  isSupportedService,
+  translateErrorCode,
+} from 'supabase-error-translator-js';
+
+const language = isSupportedLanguage(userLanguage) ? userLanguage : 'en';
+const service = isSupportedService(serviceFromLog) ? serviceFromLog : 'auth';
+
+const message = translateErrorCode(codeFromLog, service, language);
+```

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,0 +1,34 @@
+# Installation
+
+## Requirements
+
+`supabase-error-translator-js` requires Node.js 18 or newer when used in a Node.js
+environment. Browser apps can consume it through their normal bundler.
+
+## Package Manager
+
+Install from npm:
+
+```bash
+npm install supabase-error-translator-js
+```
+
+With pnpm:
+
+```bash
+pnpm add supabase-error-translator-js
+```
+
+With yarn:
+
+```bash
+yarn add supabase-error-translator-js
+```
+
+## Import
+
+```ts
+import { translateErrorCode } from 'supabase-error-translator-js';
+```
+
+The package ships JavaScript and TypeScript declaration files from `dist/`.

--- a/docs/src/language-handling.md
+++ b/docs/src/language-handling.md
@@ -1,0 +1,63 @@
+# Language Handling
+
+## Supported Codes
+
+The package uses ISO 639-1 language codes:
+
+```ts
+import { getSupportedLanguages } from 'supabase-error-translator-js';
+
+console.log(getSupportedLanguages());
+// ['en', 'ar', 'de', 'es', 'fr', 'ja', 'ko', 'pl', 'pt', 'zh']
+```
+
+## Default Language
+
+The default language is English:
+
+```ts
+import { getCurrentLanguage } from 'supabase-error-translator-js';
+
+console.log(getCurrentLanguage());
+// 'en'
+```
+
+Call `setLanguage()` to change the default:
+
+```ts
+import { setLanguage } from 'supabase-error-translator-js';
+
+setLanguage('fr');
+```
+
+Unsupported values fall back to English.
+
+## Browser Detection
+
+Pass `auto` to use the primary browser language from `navigator.language`:
+
+```ts
+import { setLanguage } from 'supabase-error-translator-js';
+
+setLanguage('auto');
+```
+
+For example, `de-DE` resolves to `de`. Unsupported browser languages fall back to `en`.
+When `navigator` is unavailable, detection also falls back to `en`.
+
+## Per-Call Language Override
+
+The third argument to `translateErrorCode()` overrides the current default without
+mutating it:
+
+```ts
+import { getCurrentLanguage, translateErrorCode } from 'supabase-error-translator-js';
+
+const message = translateErrorCode('phone_exists', 'auth', 'pt');
+
+console.log(getCurrentLanguage());
+// Still whatever was previously set.
+```
+
+This is the safer pattern for multi-user server code because `setLanguage()` stores
+module-level state.

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -1,0 +1,41 @@
+# Migration Guide
+
+## From v2 To v3
+
+Version 3 uses ISO 639-1 language codes for Japanese, Korean, and Chinese.
+
+| Before | After |
+| ------ | ----- |
+| `jp`   | `ja`  |
+| `kr`   | `ko`  |
+| `cn`   | `zh`  |
+
+Update calls like this:
+
+```ts
+import { setLanguage } from 'supabase-error-translator-js';
+
+setLanguage('ja');
+setLanguage('ko');
+setLanguage('zh');
+```
+
+`translateErrorCode()` without a `lang` argument now uses the language set by
+`setLanguage()` instead of always trying browser detection.
+
+## From v1 To v2
+
+Version 2 added service-specific translation maps. `translateErrorCode()` now requires a
+service argument.
+
+```ts
+import { translateErrorCode } from 'supabase-error-translator-js';
+
+// v1
+translateErrorCode('invalid_credentials');
+
+// v2 and newer
+translateErrorCode('invalid_credentials', 'auth');
+```
+
+Choose the service from the Supabase API that produced the error.

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -1,0 +1,40 @@
+# Quick Start
+
+Translate a Supabase Auth error code:
+
+```ts
+import { translateErrorCode } from 'supabase-error-translator-js';
+
+const message = translateErrorCode('invalid_credentials', 'auth', 'de');
+
+console.log(message);
+```
+
+Set a process-wide or browser-session default language:
+
+```ts
+import { setLanguage, translateErrorCode } from 'supabase-error-translator-js';
+
+setLanguage('es');
+
+const message = translateErrorCode('email_not_confirmed', 'auth');
+```
+
+Use browser language detection:
+
+```ts
+import { setLanguage } from 'supabase-error-translator-js';
+
+setLanguage('auto');
+```
+
+For server-side rendering or request handlers, prefer passing the language to
+`translateErrorCode()` for each call:
+
+```ts
+import { translateErrorCode, type SupportedLanguage } from 'supabase-error-translator-js';
+
+export function translateSupabaseError(code: string | undefined, userLanguage: SupportedLanguage) {
+  return translateErrorCode(code, 'auth', userLanguage);
+}
+```

--- a/docs/src/services-and-fallbacks.md
+++ b/docs/src/services-and-fallbacks.md
@@ -1,0 +1,46 @@
+# Services And Fallbacks
+
+Supabase can reuse the same error code string in different services. Because of that,
+`translateErrorCode()` requires a service argument.
+
+```ts
+import { translateErrorCode } from 'supabase-error-translator-js';
+
+translateErrorCode('TenantNotFound', 'storage', 'en');
+translateErrorCode('TenantNotFound', 'realtime', 'en');
+```
+
+## Services
+
+| Service     | Typical source                                                              |
+| ----------- | --------------------------------------------------------------------------- |
+| `auth`      | `supabase.auth.*` calls                                                     |
+| `storage`   | `supabase.storage.*` calls                                                  |
+| `realtime`  | Realtime channel and connection status errors                               |
+| `database`  | PostgreSQL SQLSTATE and PostgREST `PGRST` error codes                       |
+| `functions` | Reserved for Supabase Edge Functions. Translation maps are currently empty. |
+
+## Fallback Chain
+
+Empty, whitespace-only, or missing codes are normalized to `unknown_error`.
+
+For other codes, the lookup order is:
+
+1. Target language, selected service, selected code
+2. English, selected service, selected code
+3. Target language `unknown_error`
+4. English `unknown_error`
+
+Unsupported service names are handled defensively at runtime and return the localized
+unknown-error fallback.
+
+## Unknown Codes
+
+```ts
+import { translateErrorCode } from 'supabase-error-translator-js';
+
+const message = translateErrorCode('not_a_real_code', 'auth', 'de');
+```
+
+This returns the German unknown-error message if it exists, otherwise the English
+unknown-error message.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ module.exports = tseslint.config(
       'node_modules/',
       'dist/',
       'coverage/',
+      'docs/book/',
       '**/*.config.js',
       '**/*.config.ts',
       'eslint.config.js',


### PR DESCRIPTION
## Summary

- Add an mdBook documentation site under `docs/` with installation, quick start, language handling, fallback behavior, API reference, examples, migration, contributing, and changelog pages.
- Add a GitHub Pages workflow to build and deploy the mdBook site from `docs/book`.
- Slim the README into a project-focused overview with badges, install commands, quick start, supported languages, supported error-code areas, API exports, and links to the full manual.
- Ignore generated mdBook output in Git, Prettier, and ESLint so local docs builds do not affect source checks.

## Validation

- `mdbook build docs`
- `pnpm run prettier:check`
- `pnpm run lint`
- `pnpm run type-check`
- `pnpm run build`
- `pnpm test`
- `git diff --check`

## Notes

- Rebased onto `main` after Arabic translation support was merged.
- README and docs now reflect 10 supported languages, including Arabic (`ar`).
