### PR TITLE
ci: make PR audit job non-blocking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,9 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    # Non-blocking: dev-only transitive advisories shouldn't fail PR CI.
+    # The weekly Scheduled Security Audit (audit.yml) is the hard gate/alert.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
Makes the `Security Audit` job in `ci.yaml` non-blocking (`continue-on-error: true`).

**Why:** This package ships zero runtime dependencies (`"dependencies": {}`). The audit failures are dev-only transitive advisories (`vite` via `vitest`, `undici` via `jsdom`) that never reach consumers and can't be fixed in unrelated PRs — they were blocking routine Dependabot PRs (#32, #33).

The weekly **Scheduled Security Audit** (`audit.yml`) remains a hard gate/alert, so visibility is preserved. We'll clear the advisories when the upstream dev-dep bumps land (vite ≥ 8.0.16, undici ≥ 7.28.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)