### PR TITLE
feat(exports): add translation subpath imports and lookup API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 
 # Build output
 dist/
+.package-smoke/
 
 # Test coverage
 coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- Add per-language translation subpath imports under `supabase-error-translator-js/translations/{lang}`.
+- Add `lookupErrorCode()` for strict exact-message lookups without fallback messages.
+- Add an explicit package `exports` map for the supported public import surface.
+
+### Improvements
+
+- Freeze exported translation maps at runtime, including direct per-language subpath imports.
+- Keep `functions` reserved with intentionally empty service maps.
+
+### Compatibility
+
+- The top-level `translateErrorCode()` API and fallback behavior are unchanged.
+- Undocumented deep imports are not part of the supported API and may be blocked by the
+  package exports map.
+
 ## [3.1.0] - 2026-05-28 [Changes][v3.1.0]
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -103,6 +103,27 @@ import { translateErrorCode } from 'supabase-error-translator-js';
 const message = translateErrorCode('invalid_credentials', 'auth', 'de');
 ```
 
+Use the strict lookup API when you need to know whether a translation exists without any
+fallback message:
+
+```ts
+import { lookupErrorCode } from 'supabase-error-translator-js';
+
+const result = lookupErrorCode('invalid_credentials', 'auth', 'de');
+
+if (result.message) {
+  console.log(result.message);
+}
+```
+
+Import one immutable language map when you only need static translation data:
+
+```ts
+import de from 'supabase-error-translator-js/translations/de';
+
+console.log(de.services.auth.invalid_credentials);
+```
+
 Set a default language:
 
 ```ts
@@ -137,14 +158,27 @@ import {
   getSupportedLanguages,
   isSupportedLanguage,
   isSupportedService,
+  lookupErrorCode,
   setLanguage,
   translateErrorCode,
   SUPPORTED_LANGUAGES,
   SUPPORTED_SERVICES,
+  type ErrorCodeLookupResult,
   type ErrorService,
   type SupportedLanguage,
 } from 'supabase-error-translator-js';
 ```
+
+Public translation subpaths are also available:
+
+```ts
+import { translations } from 'supabase-error-translator-js/translations';
+import en from 'supabase-error-translator-js/translations/en';
+import de from 'supabase-error-translator-js/translations/de';
+```
+
+The exported translation maps are frozen at runtime. Undocumented deep imports are not
+part of the supported API.
 
 ## Changelog
 

--- a/__tests__/error.test.ts
+++ b/__tests__/error.test.ts
@@ -23,22 +23,10 @@ describe('Integration: translateErrorCode()', () => {
     );
   });
 
-  it('fallback chain: target service message -> English service message -> localized unknown_error', () => {
+  it('fallback chain returns target service messages and localized unknown errors', () => {
     expect(translateErrorCode('invalid_credentials', 'auth', 'de')).toBe(
       translations.de.services.auth.invalid_credentials,
     );
-
-    const originalGermanMessage = translations.de.services.auth.invalid_credentials;
-
-    try {
-      delete (translations.de.services.auth as Record<string, string>).invalid_credentials;
-
-      expect(translateErrorCode('invalid_credentials', 'auth', 'de')).toBe(
-        translations.en.services.auth.invalid_credentials,
-      );
-    } finally {
-      translations.de.services.auth.invalid_credentials = originalGermanMessage;
-    }
 
     expect(translateErrorCode('xyz123', 'functions', 'fr')).toBe(translations.fr.unknown_error);
   });

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import {
+  lookupErrorCode,
   setLanguage,
   translateErrorCode,
   getCurrentLanguage,
@@ -70,5 +71,60 @@ describe("translateErrorCode()", () => {
     expect(translateErrorCode("invalid_credentials", "auth", "zz" as any)).toBe(
       english,
     );
+  });
+});
+
+describe("lookupErrorCode()", () => {
+  beforeEach(() => setLanguage("en"));
+
+  test("returns the localized message for an exact code match", () => {
+    expect(lookupErrorCode("invalid_credentials", "auth", "de")).toEqual({
+      code: "invalid_credentials",
+      service: "auth",
+      language: "de",
+      message: translations.de.services.auth.invalid_credentials,
+    });
+  });
+
+  test("returns undefined for a missing code without fallback", () => {
+    expect(lookupErrorCode("does_not_exist", "auth", "de")).toEqual({
+      code: "does_not_exist",
+      service: "auth",
+      language: "de",
+      message: undefined,
+    });
+  });
+
+  test("returns undefined for unsupported runtime services", () => {
+    expect(lookupErrorCode("invalid_credentials", "unsupported" as any, "de")).toEqual({
+      code: "invalid_credentials",
+      service: "unsupported",
+      language: "de",
+      message: undefined,
+    });
+  });
+
+  test("unsupported runtime languages fall back to en", () => {
+    expect(lookupErrorCode("invalid_credentials", "auth", "zz" as any)).toEqual({
+      code: "invalid_credentials",
+      service: "auth",
+      language: "en",
+      message: translations.en.services.auth.invalid_credentials,
+    });
+  });
+
+  test("blank and undefined codes return undefined", () => {
+    expect(lookupErrorCode("", "auth", "en").message).toBeUndefined();
+    expect(lookupErrorCode("   ", "auth", "en").message).toBeUndefined();
+    expect(lookupErrorCode(undefined, "auth", "en").message).toBeUndefined();
+  });
+
+  test("unknown_error returns a message only when explicitly passed", () => {
+    expect(lookupErrorCode("unknown_error", "auth", "fr")).toEqual({
+      code: "unknown_error",
+      service: "auth",
+      language: "fr",
+      message: translations.fr.unknown_error,
+    });
   });
 });

--- a/__tests__/translations.test.ts
+++ b/__tests__/translations.test.ts
@@ -6,6 +6,19 @@ describe('translations index', () => {
     expect(Object.keys(translations).sort()).toEqual([...SUPPORTED_LANGUAGES].sort());
   });
 
+  it('exports immutable translation maps', () => {
+    expect(Object.isFrozen(translations)).toBe(true);
+
+    SUPPORTED_LANGUAGES.forEach((lang) => {
+      expect(Object.isFrozen(translations[lang])).toBe(true);
+      expect(Object.isFrozen(translations[lang].services)).toBe(true);
+
+      SUPPORTED_SERVICES.forEach((service) => {
+        expect(Object.isFrozen(translations[lang].services[service])).toBe(true);
+      });
+    });
+  });
+
   it('every language defines a non-empty unknown_error', () => {
     Object.values(translations).forEach((map) => {
       expect(map.unknown_error.trim().length).toBeGreaterThan(0);

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -32,6 +32,40 @@ Returns a translated string for a Supabase error code.
 | `service` | One of `auth`, `storage`, `realtime`, `database`, or `functions`.                                    |
 | `lang`    | Optional per-call language override. `auto` uses browser detection.                                  |
 
+## `lookupErrorCode(code, service, lang?)`
+
+```ts
+function lookupErrorCode(
+  code: string | undefined,
+  service: ErrorService,
+  lang?: SupportedLanguage | 'auto',
+): ErrorCodeLookupResult;
+```
+
+Performs an exact lookup without fallback messages.
+
+| Argument  | Description                                                                              |
+| --------- | ---------------------------------------------------------------------------------------- |
+| `code`    | The Supabase error code. Empty, whitespace-only, or undefined values return `undefined`. |
+| `service` | One of `auth`, `storage`, `realtime`, `database`, or `functions`.                        |
+| `lang`    | Optional per-call language override. Unsupported values resolve to `en`.                 |
+
+The result contains the normalized code, resolved language, service, and either the exact
+message or `undefined`:
+
+```ts
+type ErrorCodeLookupResult = {
+  code: string;
+  service: ErrorService;
+  language: SupportedLanguage;
+  message: string | undefined;
+};
+```
+
+`lookupErrorCode()` does not fall back to English and does not fall back to
+`unknown_error`. Passing `unknown_error` explicitly returns the localized unknown-error
+message.
+
 ## `getCurrentLanguage()`
 
 ```ts
@@ -70,8 +104,35 @@ Runtime guard for supported service names.
 import {
   SUPPORTED_LANGUAGES,
   SUPPORTED_SERVICES,
+  type ErrorCodeLookupResult,
   type ErrorService,
   type SupportedLanguage,
   type TranslationStructure,
 } from 'supabase-error-translator-js';
 ```
+
+## Translation Subpaths
+
+```ts
+import { translations } from 'supabase-error-translator-js/translations';
+import de from 'supabase-error-translator-js/translations/de';
+import en from 'supabase-error-translator-js/translations/en';
+```
+
+Supported language subpaths:
+
+```text
+supabase-error-translator-js/translations/ar
+supabase-error-translator-js/translations/de
+supabase-error-translator-js/translations/en
+supabase-error-translator-js/translations/es
+supabase-error-translator-js/translations/fr
+supabase-error-translator-js/translations/ja
+supabase-error-translator-js/translations/ko
+supabase-error-translator-js/translations/pl
+supabase-error-translator-js/translations/pt
+supabase-error-translator-js/translations/zh
+```
+
+Translation maps are immutable at runtime. The `functions` service is reserved and
+currently has empty maps.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -108,3 +108,32 @@ const service = isSupportedService(serviceFromLog) ? serviceFromLog : 'auth';
 
 const message = translateErrorCode(codeFromLog, service, language);
 ```
+
+## Strict Lookup
+
+Use `lookupErrorCode()` when application logic needs to distinguish exact translations
+from fallback messages.
+
+```ts
+import { lookupErrorCode } from 'supabase-error-translator-js';
+
+const result = lookupErrorCode('invalid_credentials', 'auth', 'de');
+
+if (result.message) {
+  console.log(result.message);
+} else {
+  console.log('No exact translation is available for this code.');
+}
+```
+
+## Per-Language Translation Data
+
+Subpath imports expose immutable static maps for each supported language.
+
+```ts
+import { translations } from 'supabase-error-translator-js/translations';
+import de from 'supabase-error-translator-js/translations/de';
+
+console.log(de.services.auth.invalid_credentials);
+console.log(translations.en.services.storage.NoSuchBucket);
+```

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -1,5 +1,25 @@
 # Migration Guide
 
+## Explicit Public Exports
+
+The package now declares an explicit public `exports` map. Documented top-level imports
+continue to work:
+
+```ts
+import { lookupErrorCode, translateErrorCode } from 'supabase-error-translator-js';
+```
+
+New public translation subpaths are available:
+
+```ts
+import { translations } from 'supabase-error-translator-js/translations';
+import de from 'supabase-error-translator-js/translations/de';
+```
+
+Undocumented deep imports, such as importing files from `dist/` directly through the
+package name, are not supported by the public API and may be blocked by the exports map.
+Use the top-level package import or the documented `translations` subpaths instead.
+
 ## From v2 To v3
 
 Version 3 uses ISO 639-1 language codes for Japanese, Korean, and Chinese.

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -10,6 +10,24 @@ const message = translateErrorCode('invalid_credentials', 'auth', 'de');
 console.log(message);
 ```
 
+Check for exact translations without fallback messages:
+
+```ts
+import { lookupErrorCode } from 'supabase-error-translator-js';
+
+const result = lookupErrorCode('invalid_credentials', 'auth', 'de');
+
+console.log(result.message);
+```
+
+Import a single immutable language map:
+
+```ts
+import de from 'supabase-error-translator-js/translations/de';
+
+console.log(de.services.auth.invalid_credentials);
+```
+
 Set a process-wide or browser-session default language:
 
 ```ts

--- a/docs/src/services-and-fallbacks.md
+++ b/docs/src/services-and-fallbacks.md
@@ -34,6 +34,23 @@ For other codes, the lookup order is:
 Unsupported service names are handled defensively at runtime and return the localized
 unknown-error fallback.
 
+## Strict Lookup
+
+`lookupErrorCode()` is intentionally different from `translateErrorCode()`: it performs
+only an exact lookup and returns `message: undefined` when no exact translation exists.
+
+```ts
+import { lookupErrorCode } from 'supabase-error-translator-js';
+
+const result = lookupErrorCode('not_a_real_code', 'auth', 'de');
+
+console.log(result.message);
+// undefined
+```
+
+Empty, whitespace-only, or missing codes also return `message: undefined`.
+`unknown_error` is returned only when that code is passed explicitly.
+
 ## Unknown Codes
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -4,6 +4,56 @@
   "description": "A comprehensive Supabase error code translator supporting 10 languages with ISO language codes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./translations": {
+      "types": "./dist/translations/index.d.ts",
+      "default": "./dist/translations/index.js"
+    },
+    "./translations/ar": {
+      "types": "./dist/translations/ar.d.ts",
+      "default": "./dist/translations/ar.js"
+    },
+    "./translations/de": {
+      "types": "./dist/translations/de.d.ts",
+      "default": "./dist/translations/de.js"
+    },
+    "./translations/en": {
+      "types": "./dist/translations/en.d.ts",
+      "default": "./dist/translations/en.js"
+    },
+    "./translations/es": {
+      "types": "./dist/translations/es.d.ts",
+      "default": "./dist/translations/es.js"
+    },
+    "./translations/fr": {
+      "types": "./dist/translations/fr.d.ts",
+      "default": "./dist/translations/fr.js"
+    },
+    "./translations/ja": {
+      "types": "./dist/translations/ja.d.ts",
+      "default": "./dist/translations/ja.js"
+    },
+    "./translations/ko": {
+      "types": "./dist/translations/ko.d.ts",
+      "default": "./dist/translations/ko.js"
+    },
+    "./translations/pl": {
+      "types": "./dist/translations/pl.d.ts",
+      "default": "./dist/translations/pl.js"
+    },
+    "./translations/pt": {
+      "types": "./dist/translations/pt.d.ts",
+      "default": "./dist/translations/pt.js"
+    },
+    "./translations/zh": {
+      "types": "./dist/translations/zh.d.ts",
+      "default": "./dist/translations/zh.js"
+    }
+  },
   "engines": {
     "node": ">=18"
   },
@@ -21,13 +71,14 @@
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "unused-code": "knip",
+    "test:package-exports": "pnpm run build && node scripts/package-exports-smoke.mjs",
     "audit:ci": "pnpm audit --audit-level=high",
     "prettier:check": "prettier --check .",
     "format": "prettier --write ."
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/srothgan/supabase-error-translator-js.git"
+    "url": "git+https://github.com/srothgan/supabase-error-translator-js.git"
   },
   "bugs": {
     "url": "https://github.com/srothgan/supabase-error-translator-js/issues"

--- a/scripts/package-exports-smoke.mjs
+++ b/scripts/package-exports-smoke.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const requirePackage = createRequire(import.meta.url);
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const languages = ['ar', 'de', 'en', 'es', 'fr', 'ja', 'ko', 'pl', 'pt', 'zh'];
+
+const relativeMain = requirePackage(path.join(root, 'dist', 'index.js'));
+assert.equal(typeof relativeMain.translateErrorCode, 'function');
+assert.equal(typeof relativeMain.lookupErrorCode, 'function');
+assert.ok(Array.isArray(relativeMain.SUPPORTED_LANGUAGES));
+
+const packageMain = requirePackage('supabase-error-translator-js');
+assert.equal(typeof packageMain.translateErrorCode, 'function');
+assert.equal(typeof packageMain.lookupErrorCode, 'function');
+assert.ok(packageMain.SUPPORTED_LANGUAGES.includes('en'));
+
+const aggregate = requirePackage('supabase-error-translator-js/translations');
+assert.ok(Object.isFrozen(aggregate.translations));
+
+for (const language of languages) {
+  const relativeModule = requirePackage(path.join(root, 'dist', 'translations', `${language}.js`));
+  const packageModule = requirePackage(`supabase-error-translator-js/translations/${language}`);
+  const relativeMap = relativeModule.default ?? relativeModule;
+  const packageMap = packageModule.default ?? packageModule;
+
+  assert.equal(typeof relativeMap.unknown_error, 'string');
+  assert.equal(typeof packageMap.unknown_error, 'string');
+  assert.ok(Object.isFrozen(packageMap));
+  assert.ok(Object.isFrozen(packageMap.services));
+}
+
+const tempDir = path.join(root, '.package-smoke');
+const typeSmokePath = path.join(tempDir, 'package-types-smoke.ts');
+
+if (existsSync(tempDir)) {
+  rmSync(tempDir, { recursive: true, force: true });
+}
+
+mkdirSync(tempDir);
+
+writeFileSync(
+  typeSmokePath,
+  `import {
+  SUPPORTED_LANGUAGES,
+  lookupErrorCode,
+  type ErrorCodeLookupResult,
+} from 'supabase-error-translator-js';
+import { translations } from 'supabase-error-translator-js/translations';
+import de from 'supabase-error-translator-js/translations/de';
+import en from 'supabase-error-translator-js/translations/en';
+
+const result: ErrorCodeLookupResult = lookupErrorCode('invalid_credentials', 'auth', 'de');
+const germanMessage: string = de.services.auth.invalid_credentials;
+const englishMessage: string = en.services.auth.invalid_credentials;
+const aggregateMessage: string = translations.en.services.auth.invalid_credentials;
+const supportedLanguages: readonly string[] = SUPPORTED_LANGUAGES;
+
+// @ts-expect-error Public translation maps are readonly.
+de.services.auth.invalid_credentials = 'changed';
+
+void [result, germanMessage, englishMessage, aggregateMessage, supportedLanguages];
+`,
+);
+
+try {
+  execFileSync(
+    process.execPath,
+    [
+      path.join(root, 'node_modules', 'typescript', 'bin', 'tsc'),
+      '--ignoreConfig',
+      '--noEmit',
+      '--module',
+      'node16',
+      '--moduleResolution',
+      'node16',
+      '--target',
+      'ES2020',
+      '--strict',
+      '--esModuleInterop',
+      '--skipLibCheck',
+      typeSmokePath,
+    ],
+    { cwd: root, stdio: 'inherit' },
+  );
+} finally {
+  rmSync(tempDir, { recursive: true, force: true });
+}

--- a/src/deep-freeze.ts
+++ b/src/deep-freeze.ts
@@ -1,0 +1,19 @@
+export type DeepReadonly<T> = T extends (...args: never[]) => unknown
+  ? T
+  : T extends readonly unknown[]
+    ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+    : T extends object
+      ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+      : T;
+
+export function deepFreeze<T extends object>(value: T): DeepReadonly<T> {
+  Object.freeze(value);
+
+  Object.values(value).forEach((property) => {
+    if (property && typeof property === 'object' && !Object.isFrozen(property)) {
+      deepFreeze(property as Record<PropertyKey, unknown>);
+    }
+  });
+
+  return value as DeepReadonly<T>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,17 @@ import { translations } from './translations';
 import { detectBrowserLanguage, isSupportedLanguage } from './languages';
 import { isSupportedService } from './services';
 import { SupportedLanguage, SUPPORTED_LANGUAGES, ErrorService } from './types';
+import type { ErrorCodeLookupResult } from './types';
 
 export { isSupportedLanguage } from './languages';
 export { isSupportedService } from './services';
 export { SUPPORTED_LANGUAGES, SUPPORTED_SERVICES } from './types';
-export type { ErrorService, SupportedLanguage, TranslationStructure } from './types';
+export type {
+  ErrorCodeLookupResult,
+  ErrorService,
+  SupportedLanguage,
+  TranslationStructure,
+} from './types';
 
 let currentLanguage: SupportedLanguage = 'en';
 
@@ -82,6 +88,31 @@ export function translateErrorCode(
 
   // 4) Final fallback: English 'unknown_error'
   return englishTranslations.unknown_error;
+}
+
+/**
+ * Strictly look up a Supabase error code without fallback messages.
+ */
+export function lookupErrorCode(
+  code: string | undefined,
+  service: ErrorService,
+  lang?: SupportedLanguage | 'auto',
+): ErrorCodeLookupResult {
+  const target = resolveLanguage(lang, currentLanguage);
+  const key = code?.trim();
+  const message =
+    key === 'unknown_error'
+      ? translations[target].unknown_error
+      : key && isSupportedService(service)
+        ? translations[target].services[service]?.[key]
+        : undefined;
+
+  return {
+    code: key ?? '',
+    service,
+    language: target,
+    message,
+  };
 }
 
 /** Get the currently active language. */

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -8,9 +8,10 @@ import ko from './translations/ko';
 import pl from './translations/pl';
 import pt from './translations/pt';
 import zh from './translations/zh';
+import { deepFreeze, type DeepReadonly } from './deep-freeze';
 import type { TranslationStructure } from './types';
 
-const translationRegistry = {
+const translationRegistry = deepFreeze({
   en,
   ar,
   de,
@@ -21,11 +22,12 @@ const translationRegistry = {
   pl,
   pt,
   zh,
-} satisfies Record<string, TranslationStructure>;
+} satisfies Record<string, TranslationStructure>);
 
 export type SupportedLanguage = keyof typeof translationRegistry;
+export type TranslationRegistry = DeepReadonly<Record<SupportedLanguage, TranslationStructure>>;
 
-export const translations: Record<SupportedLanguage, TranslationStructure> = translationRegistry;
+export const translations: TranslationRegistry = translationRegistry;
 
 export const SUPPORTED_LANGUAGES = Object.freeze(
   Object.keys(translations),

--- a/src/translations/ar.ts
+++ b/src/translations/ar.ts
@@ -1,6 +1,8 @@
 /* Arabic translations */
 
-export default {
+import { deepFreeze } from '../deep-freeze';
+
+export default deepFreeze({
   // Fallback Error Code
   unknown_error: 'حدث خطأ غير متوقَّع. يُرجى المحاولة لاحقاً.',
   services: {
@@ -294,4 +296,4 @@ export default {
     // Functions-specific errors
     functions: {},
   },
-};
+});

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1,6 +1,8 @@
 /* German translations */
 
-export default {
+import { deepFreeze } from '../deep-freeze';
+
+export default deepFreeze({
   // Fallback Error Code
   unknown_error: 'Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.',
   services: {
@@ -322,4 +324,4 @@ export default {
     // Functions-specific errors
     functions: {},
   },
-};
+});

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1,6 +1,8 @@
 /* English translations */
 
-export default {
+import { deepFreeze } from '../deep-freeze';
+
+export default deepFreeze({
   // Fallback Error Code
   unknown_error: 'An unexpected error occurred. Please try again later.',
   services: {
@@ -352,4 +354,4 @@ export default {
     // Functions-specific errors
     functions: {},
   },
-};
+});

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -1,6 +1,8 @@
 /* Spanish translations */
 
-export default {
+import { deepFreeze } from '../deep-freeze';
+
+export default deepFreeze({
   // Fallback Error Code
   unknown_error: 'Se produjo un error inesperado. Por favor, inténtelo de nuevo más tarde.',
   services: {
@@ -306,4 +308,4 @@ export default {
     // Functions-specific errors
     functions: {},
   },
-};
+});

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -1,6 +1,8 @@
 /* French translations */
 
-export default {
+import { deepFreeze } from '../deep-freeze';
+
+export default deepFreeze({
   // Fallback Error Code
   unknown_error: 'Une erreur inattendue est survenue. Veuillez réessayer plus tard.',
   services: {
@@ -317,4 +319,4 @@ export default {
     // Functions-specific errors
     functions: {},
   },
-};
+});

--- a/src/translations/ja.ts
+++ b/src/translations/ja.ts
@@ -1,6 +1,8 @@
 /* Japanese translations */
 
-export default {
+import { deepFreeze } from '../deep-freeze';
+
+export default deepFreeze({
   // Fallback Error Code
   unknown_error: '予期しないエラーが発生しました。後でもう一度お試しください。',
   services: {
@@ -358,4 +360,4 @@ export default {
     // Functions-specific errors
     functions: {},
   },
-};
+});

--- a/src/translations/ko.ts
+++ b/src/translations/ko.ts
@@ -1,6 +1,8 @@
 /* Korean translations */
 
-export default {
+import { deepFreeze } from '../deep-freeze';
+
+export default deepFreeze({
   // Fallback Error Code
   unknown_error: '예기치 않은 오류가 발생했습니다. 나중에 다시 시도해 주세요.',
   services: {
@@ -346,4 +348,4 @@ export default {
     // Functions-specific errors
     functions: {},
   },
-};
+});

--- a/src/translations/pl.ts
+++ b/src/translations/pl.ts
@@ -1,6 +1,8 @@
 /* Polish translations */
 
-export default {
+import { deepFreeze } from '../deep-freeze';
+
+export default deepFreeze({
   // Fallback Error Code
   unknown_error: 'Wystąpił nieoczekiwany błąd. Spróbuj ponownie później.',
   services: {
@@ -361,4 +363,4 @@ export default {
     // Functions-specific errors
     functions: {},
   },
-};
+});

--- a/src/translations/pt.ts
+++ b/src/translations/pt.ts
@@ -1,6 +1,8 @@
 /* Portuguese translations */
 
-export default {
+import { deepFreeze } from '../deep-freeze';
+
+export default deepFreeze({
   // Fallback Error Code
   unknown_error: 'Ocorreu um erro inesperado. Tente novamente mais tarde.',
   services: {
@@ -368,4 +370,4 @@ export default {
     // Functions-specific errors
     functions: {},
   },
-};
+});

--- a/src/translations/zh.ts
+++ b/src/translations/zh.ts
@@ -1,6 +1,8 @@
 /* Chinese Translations */
 
-export default {
+import { deepFreeze } from '../deep-freeze';
+
+export default deepFreeze({
   // Fallback Error Code
   unknown_error: '发生了意外错误，请稍后重试。',
   services: {
@@ -301,4 +303,4 @@ export default {
     // Functions-specific errors
     functions: {},
   },
-};
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,18 @@
+import type { SupportedLanguage } from './registry';
+
 export const SUPPORTED_SERVICES = ['auth', 'storage', 'realtime', 'database', 'functions'] as const;
 export type ErrorService = (typeof SUPPORTED_SERVICES)[number];
 
 export type TranslationStructure = {
   unknown_error: string;
   services: Record<ErrorService, Record<string, string>>;
+};
+
+export type ErrorCodeLookupResult = {
+  code: string;
+  service: ErrorService;
+  language: SupportedLanguage;
+  message: string | undefined;
 };
 
 export { SUPPORTED_LANGUAGES } from './registry';


### PR DESCRIPTION
﻿## Summary

Adds stable package subpath exports for translation maps, introduces a strict `lookupErrorCode()` API, and freezes exported translation data at runtime.

## Why

Consumers can import only the translation data they need, while callers that need certainty can distinguish exact translation matches from fallback UI messages. The existing top-level `translateErrorCode()` API remains unchanged.

Closes N/A

## Validation

- Automated: `pnpm run type-check`, `pnpm run lint`, `pnpm run unused-code`, `pnpm run prettier:check`, `pnpm exec vitest run --coverage.enabled=false`, `pnpm run test:package-exports`
- Manual: Verified package subpath runtime and TypeScript resolution through `scripts/package-exports-smoke.mjs`.
- Tests/coverage: Added strict lookup tests, immutability assertions, and package export smoke coverage.

## Notes

- Breaking changes: N/A for documented top-level API; undocumented deep imports may be blocked by the new `exports` map.
- Docs updated: README and mdBook pages updated.
- Security impact: N/A
