### PR TITLE
chore(release): prepare 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [3.2.0] - 2026-07-06 [Changes][v3.2.0]
 
 ### Features
 
@@ -170,6 +170,7 @@ translateErrorCode(code, service, lang);
 
 - **Auth translations**: Add initial English, German, French, and Spanish authentication translations.
 
+[v3.2.0]: https://github.com/srothgan/supabase-error-translator-js/compare/v3.1.0...v3.2.0
 [v3.1.0]: https://github.com/srothgan/supabase-error-translator-js/compare/v3.0.1...v3.1.0
 [v3.0.1]: https://github.com/srothgan/supabase-error-translator-js/compare/v3.0.0...v3.0.1
 [v3.0.0]: https://github.com/srothgan/supabase-error-translator-js/compare/v2.2.1...v3.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supabase-error-translator-js",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A comprehensive Supabase error code translator supporting 10 languages with ISO language codes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
﻿## Summary

Prepares the 3.2.0 release by finalizing the package version and changelog entry for the merged subpath exports feature set.

## Why

The release workflow publishes from `main` after CI succeeds, so the version and changelog need to be finalized in a release PR before merging.

Closes N/A

## Validation

- Automated: `pnpm run test:package-exports`, `pnpm run prettier:check`
- Manual: `npm publish --dry-run --access public`
- Tests/coverage: Package export smoke test rebuilt the package and verified subpath runtime/type resolution.

## Notes

- Breaking changes: N/A for documented top-level API; changelog notes that undocumented deep imports may be blocked by the explicit exports map.
- Docs updated: CHANGELOG.md finalized for 3.2.0.
- Security impact: N/A
