### PR TITLE
ci: drop Node 20 from test/build matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v7
 
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Summary
- Node 20 reached EOL in April 2026.
- jsdom 30 (dependabot PR #47) requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, so the Node 20 test job fails once jsdom is upgraded (`TypeError: webidl.util.markAsUncloneable is not a function`).
- Drops `20` from the `test` and `build` matrix in `.github/workflows/ci.yaml`, keeping `22` and `24`.

## Test plan
- [ ] CI passes on this PR (Test/Build for Node 22 and 24)
- [ ] After merge, rebase/retrigger #47 (jsdom bump) and confirm its Node 20 job disappears and remaining jobs pass